### PR TITLE
test(api): add safety net tests for demo-critical workflow

### DIFF
--- a/src/routes/__tests__/workflows.routes.test.ts
+++ b/src/routes/__tests__/workflows.routes.test.ts
@@ -235,3 +235,94 @@ test("POST /api/workflows rejects unsupported trigger event", async () => {
         server.close();
     }
 });
+
+test("POST /api/workflows rejects unsupported action type in steps", async () => {
+    const { server, baseUrl } = makeServer();
+    try {
+        const headers = scopeHeaders(1, 2);
+
+        const res = await fetch(`${baseUrl}/api/workflows`, {
+            method: "POST",
+            headers,
+            body: JSON.stringify(
+                validWorkflowPayload({
+                    name: "Bad Action Workflow",
+                    steps: [
+                        {
+                            id: "s1",
+                            name: "Invalid action",
+                            action: { type: "launchMissiles", params: {} },
+                        },
+                    ],
+                })
+            ),
+        });
+
+        assert.equal(res.status, 400);
+
+        const json: any = await res.json();
+        assert.equal(json.ok, false);
+        assert.equal(json.error.code, "BAD_REQUEST");
+
+        assert.ok(Array.isArray(json.error.details));
+        assert.ok(
+            json.error.details.some(
+                (e: any) =>
+                    String(e.path).includes("action.type") &&
+                    String(e.message).includes("launchMissiles")
+            )
+        );
+    } finally {
+        server.close();
+    }
+});
+
+test("PATCH /api/workflows does not mutate unintended fields", async () => {
+    const { server, baseUrl } = makeServer();
+    try {
+        const headers = scopeHeaders(1, 2);
+
+        // Create a workflow with known values
+        const createRes = await fetch(`${baseUrl}/api/workflows`, {
+            method: "POST",
+            headers,
+            body: JSON.stringify(
+                validWorkflowPayload({
+                    name: "Original Name",
+                    description: "Original description",
+                    enabled: true,
+                    trigger: { event: "issue.opened" },
+                })
+            ),
+        });
+        assert.equal(createRes.status, 201);
+
+        const created: any = await createRes.json();
+        const id = created.data.id;
+
+        // Patch only the name
+        const patchRes = await fetch(`${baseUrl}/api/workflows/${id}`, {
+            method: "PATCH",
+            headers,
+            body: JSON.stringify({ name: "Updated Name" }),
+        });
+        assert.equal(patchRes.status, 200);
+
+        const patched: any = await patchRes.json();
+        assert.equal(patched.ok, true);
+
+        // Name should be updated
+        assert.equal(patched.data.name, "Updated Name");
+
+        // All other fields should be unchanged
+        assert.equal(patched.data.description, "Original description");
+        assert.equal(patched.data.enabled, true);
+        assert.equal(patched.data.trigger.event, "issue.opened");
+        assert.equal(patched.data.scope.installationId, 1);
+        assert.equal(patched.data.scope.repositoryId, 2);
+        assert.equal(patched.data.steps.length, 1);
+        assert.equal(patched.data.steps[0].action.type, "addLabel");
+    } finally {
+        server.close();
+    }
+});

--- a/src/rules-engine/__tests__/pipeline.integration.test.ts
+++ b/src/rules-engine/__tests__/pipeline.integration.test.ts
@@ -1,0 +1,136 @@
+// src/rules-engine/__tests__/pipeline.integration.test.ts
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeWebhookEvent } from "../normalize/normalizeWebhookEvent.js";
+import { evaluateRules } from "../evaluateRules.js";
+import { executeActionStubs } from "../actions/executeActionStubs.js";
+import { InMemoryRuleStore } from "../storage/inMemoryRuleStore.js";
+import type { Rule } from "../ruleTypes.js";
+
+/**
+ * Integration test: webhook headers + payload → normalize → evaluate → execute action stubs.
+ * Validates that the full pipeline runs without throwing and produces expected results.
+ */
+test("pipeline: normalize → evaluate → execute does not throw and produces correct results", async () => {
+    // 1. Simulate a GitHub pull_request.opened webhook
+    const headers: Record<string, string> = {
+        "x-github-event": "pull_request",
+        "x-github-delivery": "test-delivery-001",
+        "x-hub-signature-256": "unused-in-this-test",
+    };
+
+    const payload = {
+        action: "opened",
+        installation: { id: 99 },
+        repository: {
+            id: 42,
+            full_name: "octo/repo",
+        },
+        sender: { login: "testuser", id: 7 },
+        pull_request: {
+            id: 1001,
+            number: 5,
+            title: "[WIP] Add feature",
+            body: "Work in progress",
+            state: "open",
+            draft: true,
+            html_url: "https://github.com/octo/repo/pull/5",
+            user: { login: "testuser" },
+            base: { ref: "main", sha: "abc123" },
+            head: { ref: "feature-branch", sha: "def456" },
+            labels: [{ name: "draft" }],
+        },
+    };
+
+    // 2. Normalize — should not throw
+    const ctx = normalizeWebhookEvent({ headers, payload });
+
+    assert.equal(ctx.event.name, "pull_request.opened");
+    assert.equal(ctx.installationId, 99);
+    assert.equal(ctx.repository.id, 42);
+    assert.equal(ctx.repository.fullName, "octo/repo");
+    assert.equal(ctx.actor?.login, "testuser");
+
+    // 3. Seed a matching rule
+    const store = new InMemoryRuleStore();
+
+    const rule: Rule = {
+        id: "test-pipeline-rule",
+        name: "Label WIP PRs",
+        enabled: true,
+        trigger: { event: "pull_request.opened" },
+        conditions: {
+            type: "leaf",
+            path: "pullRequest.title",
+            op: "contains",
+            value: "[WIP]",
+        },
+        actions: [
+            { type: "addLabel", params: { label: "wip" } },
+        ],
+        evaluation: { mode: "allMatches" },
+    };
+
+    await store.upsertRulesForRepo(
+        { installationId: 99, repositoryId: 42 },
+        [rule]
+    );
+
+    // 4. Evaluate — should not throw, should match the rule
+    const evalResult = await evaluateRules(store, { ctx });
+
+    assert.deepEqual(evalResult.matchedRuleIds, ["test-pipeline-rule"]);
+    assert.equal(evalResult.actions.length, 1);
+
+    const matchedAction = evalResult.actions[0];
+    assert.ok(matchedAction, "Expected actions[0] to exist");
+    assert.equal(matchedAction.type, "addLabel");
+    assert.equal(matchedAction.ruleId, "test-pipeline-rule");
+
+    // 5. Execute action stubs — should not throw, should succeed
+    const actionResults = await executeActionStubs({
+        ctx,
+        actions: evalResult.actions,
+    });
+
+    assert.equal(actionResults.length, 1);
+
+    const stubResult = actionResults[0];
+    assert.ok(stubResult, "Expected actionResults[0] to exist");
+    assert.equal(stubResult.ok, true);
+    assert.equal(stubResult.actionType, "addLabel");
+    assert.equal(stubResult.ruleId, "test-pipeline-rule");
+});
+
+test("pipeline: normalize → evaluate with no matching rules produces empty results", async () => {
+    const headers: Record<string, string> = {
+        "x-github-event": "push",
+        "x-github-delivery": "test-delivery-002",
+    };
+
+    const payload = {
+        installation: { id: 99 },
+        repository: {
+            id: 42,
+            full_name: "octo/repo",
+        },
+        sender: { login: "testuser", id: 7 },
+        ref: "refs/heads/main",
+        before: "000000",
+        after: "aaaaaa",
+        commits: [],
+    };
+
+    // Normalize
+    const ctx = normalizeWebhookEvent({ headers, payload });
+    assert.equal(ctx.event.name, "push");
+
+    // Evaluate against empty store
+    const store = new InMemoryRuleStore();
+    const evalResult = await evaluateRules(store, { ctx });
+
+    assert.deepEqual(evalResult.matchedRuleIds, []);
+    assert.deepEqual(evalResult.actions, []);
+});


### PR DESCRIPTION
resolves issue #39 

Audit Results — all tasks verified:

- Scope required on all workflow endpoints — tested (401 on missing headers)

- Invalid trigger values rejected — tested (deployment.created → 400)
- Invalid actionType values rejected — new test (launchMissiles → 400)
- Update does not mutate unintended fields — new test (patch name only, assert all other fields unchanged)
- Deterministic rule ordering — tested (priority desc, id asc)
- Disabled rules ignored — tested (disabled + non-matching triggers → empty results)
- Full pipeline does not throw — new integration test (normalize → evaluate → execute with matching rule + empty store)
- npm test passes reliably — 37/37 passing

Files added/modified:

- src/routes/__tests__/workflows.routes.test.ts — 2 new tests
- src/rules-engine/__tests__/pipeline.integration.test.ts — new file, 2 tests